### PR TITLE
feat(api): stub route handlers for missing /api/cli/* endpoints

### DIFF
--- a/apps/web/src/app/api/cli/me/route.ts
+++ b/apps/web/src/app/api/cli/me/route.ts
@@ -1,0 +1,29 @@
+/**
+ * GET /api/cli/me
+ *
+ * Returns the current authenticated user's profile for CLI identity checks.
+ *
+ * Expected by: packages/cli/src/lib/api-client.ts — verifyAuth()
+ *
+ * Request:
+ *   Authorization: Bearer <access_token>
+ *
+ * Response 200:
+ *   { email: string, tier: "free" | "premium" }
+ *
+ * Response 401:
+ *   { error: "unauthorized" }
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  // TODO: Validate bearer token from Authorization header
+  // TODO: Look up user by token and return { email, tier }
+
+  return NextResponse.json(
+    { error: "Not implemented", message: "CLI user endpoint is not yet wired up server-side" },
+    { status: 501 }
+  );
+}

--- a/apps/web/src/app/api/cli/premium-packs/[id]/install/route.ts
+++ b/apps/web/src/app/api/cli/premium-packs/[id]/install/route.ts
@@ -1,0 +1,72 @@
+/**
+ * POST /api/cli/premium-packs/:id/install
+ * DELETE /api/cli/premium-packs/:id/install
+ *
+ * Install or uninstall a premium pack for the authenticated user.
+ *
+ * Expected by: packages/cli/src/commands/premium-packs.ts
+ *   — installPremiumPack() (POST)
+ *   — uninstallPremiumPack() (DELETE)
+ *
+ * POST Request:
+ *   Authorization: Bearer <access_token>
+ *   Body (optional): { tool?: string }
+ *
+ * POST Response 200:
+ *   {
+ *     installed: boolean;
+ *     alreadyInstalled?: boolean;
+ *     packId: string;
+ *     installedAt?: string | null;
+ *   }
+ *
+ * DELETE Request:
+ *   Authorization: Bearer <access_token>
+ *
+ * DELETE Response 200:
+ *   {
+ *     uninstalled: boolean;
+ *     removed: boolean;
+ *     packId: string;
+ *   }
+ *
+ * Response 401: { error: "unauthorized" }
+ * Response 403: { error: "premium subscription required" }
+ * Response 404: { error: "Pack not found" }
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // TODO: Validate bearer token from Authorization header
+  // TODO: Verify user has premium tier
+  // TODO: Look up pack by id (404 if missing)
+  // TODO: Record install for user, return { installed, packId, installedAt }
+
+  return NextResponse.json(
+    { error: "Not implemented", message: `CLI pack install for '${id}' is not yet wired up server-side` },
+    { status: 501 }
+  );
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // TODO: Validate bearer token from Authorization header
+  // TODO: Verify user has premium tier
+  // TODO: Remove install record for user, return { uninstalled, removed, packId }
+
+  return NextResponse.json(
+    { error: "Not implemented", message: `CLI pack uninstall for '${id}' is not yet wired up server-side` },
+    { status: 501 }
+  );
+}

--- a/apps/web/src/app/api/cli/premium-packs/[id]/route.ts
+++ b/apps/web/src/app/api/cli/premium-packs/[id]/route.ts
@@ -1,0 +1,61 @@
+/**
+ * GET /api/cli/premium-packs/:id
+ *
+ * Returns full detail for a single premium pack, including its prompts.
+ *
+ * Expected by: packages/cli/src/commands/premium-packs.ts — fetchPremiumPackDetail()
+ *
+ * Request:
+ *   Authorization: Bearer <access_token>
+ *
+ * Response 200:
+ *   {
+ *     pack: {
+ *       id: string;
+ *       title: string;
+ *       description?: string | null;
+ *       coverImage?: string | null;
+ *       version?: string | null;
+ *       installCount?: number | null;
+ *       promptCount: number;
+ *       isInstalled: boolean;
+ *       installedAt?: string | null;
+ *       publishedAt?: string | null;
+ *       changelog?: string | null;
+ *       category?: { id, name, slug, icon?, color? } | null;
+ *       prompts: Array<{
+ *         id: string;
+ *         title: string;
+ *         description?: string | null;
+ *         content?: string | null;
+ *         version?: string | null;
+ *         accessLevel?: string | null;
+ *         position?: number;
+ *       }>;
+ *     }
+ *   }
+ *
+ * Response 401: { error: "unauthorized" }
+ * Response 403: { error: "premium subscription required" }
+ * Response 404: { error: "Pack not found" }
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+
+  // TODO: Validate bearer token from Authorization header
+  // TODO: Verify user has premium tier
+  // TODO: Look up pack by id, include prompts
+  // TODO: Return { pack } or 404
+
+  return NextResponse.json(
+    { error: "Not implemented", message: `CLI premium-pack detail for '${id}' is not yet wired up server-side` },
+    { status: 501 }
+  );
+}

--- a/apps/web/src/app/api/cli/premium-packs/route.ts
+++ b/apps/web/src/app/api/cli/premium-packs/route.ts
@@ -1,0 +1,55 @@
+/**
+ * GET /api/cli/premium-packs
+ *
+ * Lists available premium packs for the authenticated user.
+ *
+ * Expected by: packages/cli/src/commands/premium-packs.ts — listPremiumPacks()
+ *
+ * Request:
+ *   Authorization: Bearer <access_token>
+ *   Query params:
+ *     installed? — "true" to filter to installed packs only
+ *
+ * Response 200:
+ *   {
+ *     packs: Array<{
+ *       id: string;
+ *       title: string;
+ *       description?: string | null;
+ *       coverImage?: string | null;
+ *       version?: string | null;
+ *       installCount?: number | null;
+ *       promptCount: number;
+ *       isInstalled: boolean;
+ *       installedAt?: string | null;
+ *       publishedAt?: string | null;
+ *       category?: {
+ *         id: string;
+ *         name: string;
+ *         slug: string;
+ *         icon?: string | null;
+ *         color?: string | null;
+ *       } | null;
+ *     }>;
+ *     installedOnly: boolean;
+ *   }
+ *
+ * Response 401: { error: "unauthorized" }
+ * Response 403: { error: "premium subscription required" }
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  // TODO: Validate bearer token from Authorization header
+  // TODO: Verify user has premium tier
+  // TODO: Read ?installed param
+  // TODO: Query packs catalog, annotate with user's install status
+  // TODO: Return { packs, installedOnly }
+
+  return NextResponse.json(
+    { error: "Not implemented", message: "CLI premium-packs list endpoint is not yet wired up server-side" },
+    { status: 501 }
+  );
+}

--- a/apps/web/src/app/api/cli/sync/route.ts
+++ b/apps/web/src/app/api/cli/sync/route.ts
@@ -1,0 +1,48 @@
+/**
+ * GET /api/cli/sync
+ *
+ * Syncs the authenticated user's premium prompt library to local CLI cache.
+ *
+ * Expected by: packages/cli/src/commands/sync.ts — syncCommand()
+ *
+ * Request:
+ *   Authorization: Bearer <access_token>
+ *   Query params:
+ *     since? — ISO 8601 timestamp for incremental sync
+ *
+ * Response 200:
+ *   {
+ *     prompts: Array<{
+ *       id: string;
+ *       title: string;
+ *       description?: string;
+ *       content: string;
+ *       category?: string;
+ *       tags?: string[];
+ *       version?: string;
+ *       created?: string;
+ *       updated?: string;
+ *     }>;
+ *     total: number;
+ *     last_modified: string;   // ISO 8601
+ *   }
+ *
+ * Response 401: { error: "unauthorized" }
+ * Response 403: { error: "premium subscription required" }
+ */
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  // TODO: Validate bearer token from Authorization header
+  // TODO: Verify user has premium tier
+  // TODO: Read ?since param for incremental sync
+  // TODO: Query premium prompts owned/accessible by user
+  // TODO: Return { prompts, total, last_modified }
+
+  return NextResponse.json(
+    { error: "Not implemented", message: "CLI sync endpoint is not yet wired up server-side" },
+    { status: 501 }
+  );
+}


### PR DESCRIPTION
## Problem

The CLI (`packages/cli`) calls six `/api/cli/*` API endpoints that have no corresponding route handlers in the Next.js app (`apps/web/src/app/api/`). This causes all premium CLI features that depend on server communication to fail:

| CLI Command | Endpoint Called | Failure |
|---|---|---|
| `jfp sync` | `GET /api/cli/sync` | 405 "Method Not Allowed" |
| `jfp sync --status` | (works — reads local state only) | n/a |
| `jfp packs list` | `GET /api/cli/premium-packs` | Returns empty array (error swallowed) |
| `jfp packs install <id>` | `POST /api/cli/premium-packs/:id/install` | "Failed to install premium pack" |
| `jfp packs show <id>` | `GET /api/cli/premium-packs/:id` | "Pack not found" |
| `verifyAuth()` | `GET /api/cli/me` | Silent failure |

The 405 is Next.js/Vercel's default response when no route.ts file exists for a requested path. The CLI client code in `packages/cli/src/commands/sync.ts` and `packages/cli/src/commands/premium-packs.ts` is fully implemented — it's the server-side route handlers that are missing.

## Provenance

No files under `apps/web/src/app/api/cli/` exist on `main`. Full route listing confirms this — there are 46 route.ts files under `/api/` but zero under `/api/cli/`:

```
apps/web/src/app/api/admin/...      (11 routes)
apps/web/src/app/api/appeals/...    
apps/web/src/app/api/dmca/...       
apps/web/src/app/api/export/...     
...
apps/web/src/app/api/cli/           ← does not exist
```

Meanwhile the CLI's `api-client.ts` resolves its base URL to `https://pro.jeffreysprompts.com/api` and appends `/cli/sync`, `/cli/premium-packs`, etc.

## What this PR adds

Five skeleton `route.ts` files that return **501 Not Implemented** with TODO comments documenting the exact request/response contracts the CLI expects:

```
apps/web/src/app/api/cli/
├── me/route.ts                           GET
├── sync/route.ts                         GET
└── premium-packs/
    ├── route.ts                          GET
    └── [id]/
        ├── route.ts                      GET
        └── install/route.ts              POST, DELETE
```

Each stub's JSDoc block includes the full TypeScript interface the CLI deserializes into (derived from `SyncResponse`, `PacksListResponse`, `PackDetailResponse`, `PackInstallResponse`, `PackUninstallResponse` in the CLI source). This should make it straightforward to wire up the real data layer without re-reading the CLI code.

## Why 501 stubs instead of full implementation

The data layer (user auth, premium entitlements, pack catalog, install tracking) doesn't exist in the public repo — these stubs document the API contract so the implementation can be filled in against whatever backing store is used. Returning 501 instead of letting Next.js return 405 also gives CLI users a clearer error message.

## Test plan

- [ ] Verify the five new route files don't break existing API routes or the build
- [ ] Wire up real auth + data layer behind each stub
- [ ] Confirm `jfp sync` and `jfp packs list` work end-to-end after implementation